### PR TITLE
feat: Adds new scripts and commands

### DIFF
--- a/source-code/commands/dropbox
+++ b/source-code/commands/dropbox
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+
+
+
+~/.dropbox-dist/dropboxd

--- a/source-code/commands/ryujinx
+++ b/source-code/commands/ryujinx
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+
+
+
+
+flatpak run org.ryujinx.Ryujinx

--- a/source-code/commands/snes9x
+++ b/source-code/commands/snes9x
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+
+
+
+
+flatpak run com.snes9x.Snes9x

--- a/source-code/commands/upd-sys
+++ b/source-code/commands/upd-sys
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+
+
+
+sudo apt update -y
+sudo apt upgrade -y
+sudo apt autoremove -y
+sudo apt autoclean -y

--- a/source-code/scripts/commands
+++ b/source-code/scripts/commands
@@ -11,7 +11,10 @@ commands() {
     # dropbox
     chmod +x installers/dropbox
 
-    
+    # ryujinx
+    chmod +x installers/ryujinx
+
+
 
     sudo mv installers/* /bin/
 }

--- a/source-code/scripts/commands
+++ b/source-code/scripts/commands
@@ -14,6 +14,9 @@ commands() {
     # ryujinx
     chmod +x installers/ryujinx
 
+    # snes9x
+    chmod +x installers/snes9x
+
 
 
     sudo mv installers/* /bin/

--- a/source-code/scripts/commands
+++ b/source-code/scripts/commands
@@ -1,0 +1,13 @@
+!#/bin/bash
+
+
+
+
+
+commands() {
+    # upd-sys
+    chmod +x installers/upd-sys 
+
+
+    sudo mv installers/* /bin/
+}

--- a/source-code/scripts/commands
+++ b/source-code/scripts/commands
@@ -8,6 +8,10 @@ commands() {
     # upd-sys
     chmod +x installers/upd-sys 
 
+    # dropbox
+    chmod +x installers/dropbox
+
+    
 
     sudo mv installers/* /bin/
 }


### PR DESCRIPTION
Adds new scripts and commands to the Ubuntu-Gamer project.

## Details

- upd-sys:
    - Created upd-sys, a simple abstraction of the system update commands.
- command scripts:
    - Introduced a set of command scripts.
    - The scripts were moved to the binaries folder and given appropriate permissions.
- dropbox:
    - Implemented the dropbox command.
- ryujinx:
    - Implemented support for ryujinx, a Nintendo Switch emulator.
- snes9x:
    - Implemented support for snes9x, a Super Nintendo emulator.